### PR TITLE
ci: Add Pull Request Title Check

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,27 @@
+name: "Pull Request Checks"
+
+on:
+  pull_request:
+    types:
+      [
+        opened,
+        edited,
+        unlocked,
+        labeled,
+        synchronize,
+        reopened,
+        ready_for_review,
+      ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-pr-title:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title
+        uses: deepakputhraya/action-pr-title@v1.0.2
+        with:
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new GitHub Actions workflow for pull request checks. The workflow, named "Pull Request Checks," is triggered on various pull request events such as opening, editing, unlocking, labeling, synchronising, reopening, and when a pull request is ready for review.

The workflow includes a single job that checks the pull request title using the `deepakputhraya/action-pr-title@v1.0.2` action. It enforces a specific format for PR titles by allowing only certain prefixes. The allowed prefixes include:

- feat:
- fix:
- bug:
- ci:
- refactor:
- docs:
- build:
- chore(
- deps(
- chore:
- feat!:
- fix!:
- refactor!:
- test:

This standardisation of pull request titles will improve the consistency and clarity of the project's commit history and changelog.

fixes #5