### PR TITLE
ci: Add PR labeler workflow and configuration

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -1,0 +1,35 @@
+# labels auto assigned to PR, keep in sync with labels.yml
+documentation:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["README.md", "docs/**"]
+dependencies:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/poetry.lock", "package-lock.json"]
+      - head-branch: ["^dependabot"]
+python:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["*.py", "**/*.py"]
+just:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["Justfile", "**/*.just"]
+shell:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/*.sh"]
+github_actions:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [".github/workflows/*", ".github/workflows/**/*"]
+analyser:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["analyser/**"]
+git_hooks:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["githooks/**"]

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -25,3 +25,11 @@ jobs:
         uses: deepakputhraya/action-pr-title@v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix
+  labeller:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/other-configurations/labeller.yml
+          sync-labels: true


### PR DESCRIPTION
# Pull Request

## Description

This change introduces an automated labelling system for pull requests using GitHub Actions. The key additions are:

1. A new `labeller.yml` file in the `.github/other-configurations/` directory, which defines rules for automatically assigning labels to pull requests based on file changes and branch names.

2. An update to the `pull-request-checks.yml` workflow file, adding a new job called `labeller` that uses the `actions/labeler@v5` action to apply the labelling rules.

The labelling rules cover various categories such as documentation, dependencies, Python code, Just files, shell scripts, GitHub Actions, analyser, and git hooks. This automation will help streamline the pull request process by automatically categorising changes, making it easier for reviewers to identify the nature of the modifications.

fixes #8