### PR TITLE
chore: Update Justfile with new tasks and refactor existing ones

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,8 +3,8 @@
 # ------------------------------------------------------------------------------
 
 clean:
-    just analyser::clean-repos
-    just analyser::clean-generated-files
+    just clean-repos
+    just clean-generated-files
     find . \( \
       -name '__pycache__' -o \
       -name '.coverage' -o \
@@ -28,16 +28,16 @@ install:
     poetry install
 
 run:
-    poetry run python -m application
+    poetry run python -m analyser
 
 run-with-defaults:
-    DEBUG=true REPOSITORY_OWNER=JackPlowman poetry run python -m application
+    DEBUG=true REPOSITORY_OWNER=JackPlowman poetry run python -m analyser
 
 unit-test:
-    poetry run pytest application --cov=application --cov-report=xml
+    poetry run pytest analyser --cov=analyser --cov-report=xml
 
 unit-test-debug:
-    poetry run pytest application --cov=application --cov-report=xml -vvvv
+    poetry run pytest analyser --cov=analyser --cov-report=xml -vvvv
 
 # ------------------------------------------------------------------------------
 # Ruff - # Set up red-knot when it's ready
@@ -65,3 +65,33 @@ ruff-format-fix:
 
 vulture:
     poetry run vulture application
+
+# ------------------------------------------------------------------------------
+# Prettier
+# ------------------------------------------------------------------------------
+
+prettier-check:
+    prettier . --check
+
+prettier-format:
+    prettier . --check --write
+
+# ------------------------------------------------------------------------------
+# Justfile
+# ------------------------------------------------------------------------------
+
+format:
+    just --fmt --unstable
+
+format-check:
+    just --fmt --check --unstable
+
+# ------------------------------------------------------------------------------
+# Git Hooks
+# ------------------------------------------------------------------------------
+
+# Install pre commit hook to run on all commits
+install-git-hooks:
+    cp -f githooks/pre-commit .git/hooks/pre-commit
+    cp -f githooks/post-commit .git/hooks/post-commit
+    chmod ug+x .git/hooks/*


### PR DESCRIPTION
# Pull Request

## Description

This change updates the Justfile with several modifications:

1. Simplified the `clean` task by removing the `analyser::` prefix from its commands.

2. Updated the `run` and `run-with-defaults` tasks to use `analyser` instead of `application` as the main module.

3. Modified the `unit-test` and `unit-test-debug` tasks to target the `analyser` directory instead of `application`.

4. Added new tasks for Prettier:
   - `prettier-check`: Checks formatting without making changes
   - `prettier-format`: Checks and applies formatting changes

5. Introduced Justfile-specific tasks:
   - `format`: Formats the Justfile
   - `format-check`: Checks the Justfile formatting

6. Added Git hooks tasks:
   - `install-git-hooks`: Copies and sets up pre-commit and post-commit hooks

These changes aim to improve the project's structure, enhance code quality checks, and streamline the development workflow.

fixes #11