### PR TITLE
ci: Add Justfile format check to code quality workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -70,3 +70,18 @@ jobs:
 
       - name: Check Python Code for Dead Code (Vulture)
         run: just vulture
+
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+
+      - name: Check Justfile Format
+        run: just format-check


### PR DESCRIPTION
# Pull Request

## Description

This change adds a new job to the code quality workflow to check the formatting of the Justfile. The new job, named "Check Justfile Format", runs on Ubuntu and performs the following steps:

1. Checks out the repository
2. Sets up the Just command runner
3. Executes the `just format-check` command to verify the Justfile's formatting

This addition enhances the existing code quality checks by ensuring that the Justfile adheres to consistent formatting standards.

fixes #39