### PR TITLE
ci: Add Markdown link checker to code quality workflow

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,7 @@
+dirs:
+  - ./
+  - ./docs
+excludedFiles:
+  - ./CHANGELOG.md
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -71,6 +71,24 @@ jobs:
       - name: Check Python Code for Dead Code (Vulture)
         run: just vulture
 
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.1
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter
+
   check-justfile-format:
     name: Check Justfile Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new workflow to check Markdown links in the repository. The key updates include:

1. Added a new configuration file `.github/other-configurations/.linkspector.yml` for the link checking tool. This file specifies:
   - Directories to scan: root and docs
   - Files to exclude: CHANGELOG.md
   - Acceptable HTTP status code: 200

2. Updated the `.github/workflows/code-quality.yml` file to include a new job called "Check Markdown links". This job:
   - Uses the UmbrellaDocs/action-linkspector@v1.2.1 action
   - Configures the action with the newly added .linkspector.yml file
   - Sets up GitHub PR review reporting
   - Fails the workflow if any broken links are found

This addition will help maintain the integrity of documentation and references throughout the project by automatically checking for broken links in Markdown files.

fixes #40