### PR TITLE
chore: Add .gitattributes for JSON and YAML detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.json linguist-detectable
+*.yml linguist-detectable


### PR DESCRIPTION
# Pull Request

## Description

This change adds a new `.gitattributes` file to the repository. The file includes two lines that mark JSON and YAML files as linguist-detectable. This configuration ensures that GitHub's Linguist tool properly recognises and categorises these file types when determining the repository's language statistics and syntax highlighting.

fixes #41