### PR TITLE
chore: Add .prettierignore file to exclude CHANGELOG.md

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
# Pull Request

## Description

This change adds a `.prettierignore` file to the project, specifically excluding the `CHANGELOG.md` file from Prettier formatting. This ensures that the changelog maintains its original formatting and structure, which is often important for readability and consistency across version control systems.

fixes #42