### PR TITLE
chore: Add GitHub issue templates and config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: ""
+assignees: ""
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: ""
+assignees: ""
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
# Pull Request

## Description

This change introduces GitHub issue templates to streamline the process of reporting bugs and requesting features. The following templates have been added:

1. A bug report template (`bug_report.md`) that prompts users to provide:
   - A description of the bug
   - Steps to reproduce the issue
   - Expected behavior
   - Screenshots (if applicable)
   - System information (OS, browser, version)
   - Additional context

2. A feature request template (`feature_request.md`) that asks users to provide:
   - The problem or need behind the feature request
   - A description of the desired solution
   - Alternative solutions considered
   - Additional context or screenshots

Additionally, a `config.yml` file has been added to disable blank issues, ensuring that all new issues use one of the provided templates.

These templates will help standardise issue reporting, making it easier for contributors to provide necessary information and for maintainers to triage and address issues more efficiently.

fixes #51