### PR TITLE
chore: Add Git hooks for pre-commit and post-commit checks

### DIFF
--- a/githooks/post-commit
+++ b/githooks/post-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e +x
+
+git update-index -g

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e +x
+
+# shellcheck disable=SC2045,SC2028,SC2086,SC2206,SC2128
+for script in $(ls -1 githooks/pre-commit-scripts/*.sh 2>/dev/null); do
+  ts=$SECONDS
+  echo "Running githook: $script"
+  bash $script
+  te=($SECONDS - $ts)
+  echo "Script Took (${te}s)"
+done
+
+printf "pre-commit completed successfully"

--- a/githooks/pre-commit-scripts/gitleaks.sh
+++ b/githooks/pre-commit-scripts/gitleaks.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e +x
+
+gitleaks detect --source .

--- a/githooks/pre-commit-scripts/justfile.sh
+++ b/githooks/pre-commit-scripts/justfile.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e +x
+
+just format

--- a/githooks/pre-commit-scripts/prettier.sh
+++ b/githooks/pre-commit-scripts/prettier.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e +x
+
+just prettier-format

--- a/githooks/pre-commit-scripts/python.sh
+++ b/githooks/pre-commit-scripts/python.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e +x
+
+just install
+just ruff-fix


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a set of Git hooks and pre-commit scripts to enhance the development workflow:

1. Added a post-commit hook that updates the Git index.

2. Implemented a pre-commit hook that executes a series of scripts located in the `githooks/pre-commit-scripts/` directory.

3. Created four pre-commit scripts:
   - `gitleaks.sh`: Runs Gitleaks to detect potential secrets in the codebase.
   - `justfile.sh`: Executes the `just format` command.
   - `prettier.sh`: Runs the `just prettier-format` command for code formatting.
   - `python.sh`: Installs dependencies and runs Ruff for Python code linting and fixing.

These hooks and scripts aim to automate various checks and formatting tasks, ensuring code quality and consistency before each commit.

fixes #47